### PR TITLE
Ticker() init performance boost

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -71,18 +71,10 @@ class TickerBase():
         self._earnings_dates = None
         self._earnings_history = None
 
-        self._earnings = {
-            "yearly": utils.empty_df(),
-            "quarterly": utils.empty_df()}
-        self._financials = {
-            "yearly": utils.empty_df(),
-            "quarterly": utils.empty_df()}
-        self._balancesheet = {
-            "yearly": utils.empty_df(),
-            "quarterly": utils.empty_df()}
-        self._cashflow = {
-            "yearly": utils.empty_df(),
-            "quarterly": utils.empty_df()}
+        self._earnings = None
+        self._financials = None
+        self._balancesheet = None
+        self._cashflow = None
 
         # accept isin as ticker
         if utils.is_isin(self.ticker):
@@ -496,6 +488,9 @@ class TickerBase():
         data = utils.get_json(ticker_url + '/financials', proxy, self.session)
 
         # generic patterns
+        self._cashflow = {"yearly": utils.empty_df(), "quarterly": utils.empty_df()}
+        self._balancesheet = {"yearly": utils.empty_df(), "quarterly": utils.empty_df()}
+        self._financials = {"yearly": utils.empty_df(), "quarterly": utils.empty_df()}
         for key in (
             (self._cashflow, 'cashflowStatement', 'cashflowStatements'),
             (self._balancesheet, 'balanceSheet', 'balanceSheetStatements'),
@@ -520,6 +515,7 @@ class TickerBase():
             try:
                 earnings = data['earnings']['financialsChart']
                 earnings['financialCurrency'] = 'USD' if 'financialCurrency' not in data['earnings'] else data['earnings']['financialCurrency']
+                self._earnings = {"yearly": utils.empty_df(), "quarterly": utils.empty_df()}
                 self._earnings['financialCurrency'] = earnings['financialCurrency']
                 df = _pd.DataFrame(earnings['yearly']).set_index('date')
                 df.columns = utils.camel2title(df.columns)

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -488,6 +488,7 @@ class TickerBase():
         data = utils.get_json(ticker_url + '/financials', proxy, self.session)
 
         # generic patterns
+        self._earnings = {"yearly": utils.empty_df(), "quarterly": utils.empty_df()}
         self._cashflow = {"yearly": utils.empty_df(), "quarterly": utils.empty_df()}
         self._balancesheet = {"yearly": utils.empty_df(), "quarterly": utils.empty_df()}
         self._financials = {"yearly": utils.empty_df(), "quarterly": utils.empty_df()}
@@ -515,7 +516,6 @@ class TickerBase():
             try:
                 earnings = data['earnings']['financialsChart']
                 earnings['financialCurrency'] = 'USD' if 'financialCurrency' not in data['earnings'] else data['earnings']['financialCurrency']
-                self._earnings = {"yearly": utils.empty_df(), "quarterly": utils.empty_df()}
                 self._earnings['financialCurrency'] = earnings['financialCurrency']
                 df = _pd.DataFrame(earnings['yearly']).set_index('date')
                 df.columns = utils.camel2title(df.columns)


### PR DESCRIPTION
When running `Ticker()` many times the init time is significant. Caused by `utils.empty_df()` calls, but these can be moved out into `get_fundamentals()`. Reduces runtime of 1000 calls from seconds to milliseconds, doesn't affect fundamentals.