### PR TITLE
Fix dividends & splits

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -313,20 +313,16 @@ class TickerBase():
         if actions:
             df = df.sort_index()
             if dividends.shape[0] > 0:
-                # Discard dividends that occurred before quotes
-                dividends = dividends[dividends.index >= quotes.index[0]]
-
                 df = utils.safe_merge_dfs(df, dividends, interval)
+            if "Dividends" in df.columns:
                 f_na = df["Dividends"].isna()
                 df.loc[f_na,"Dividends"] = 0
             else:
                 df["Dividends"] = 0.0
             #
             if splits.shape[0] > 0:
-                # Discard splits that occurred before quotes
-                splits = splits[splits.index >= quotes.index[0]]
-
                 df = utils.safe_merge_dfs(df, splits, interval)
+            if "Stock Splits" in df.columns:
                 f_na = df["Stock Splits"].isna()
                 df.loc[f_na,"Stock Splits"] = 0
             else:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -313,11 +313,8 @@ class TickerBase():
         if actions:
             df = df.sort_index()
             if dividends.shape[0] > 0:
-                # Discard from dividends any rows that fall outside of quotes intervals
+                # Discard dividends that occurred before quotes
                 dividends = dividends[dividends.index >= quotes.index[0]]
-                last_main_dt = quotes.index[-1]
-                last_main_dt_end = last_main_dt + utils.interval_to_timedelta(interval)
-                dividends = dividends[dividends.index < last_main_dt_end]
 
                 df = utils.safe_merge_dfs(df, dividends, interval)
                 f_na = df["Dividends"].isna()
@@ -326,11 +323,8 @@ class TickerBase():
                 df["Dividends"] = 0.0
             #
             if splits.shape[0] > 0:
-                # Discard from splits any rows that fall outside of quotes intervals
+                # Discard splits that occurred before quotes
                 splits = splits[splits.index >= quotes.index[0]]
-                last_main_dt = quotes.index[-1]
-                last_main_dt_end = last_main_dt + utils.interval_to_timedelta(interval)
-                splits = splits[splits.index < last_main_dt_end]
 
                 df = utils.safe_merge_dfs(df, splits, interval)
                 f_na = df["Stock Splits"].isna()

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -313,6 +313,12 @@ class TickerBase():
         if actions:
             df = df.sort_index()
             if dividends.shape[0] > 0:
+                # Discard from dividends any rows that fall outside of quotes intervals
+                dividends = dividends[dividends.index >= quotes.index[0]]
+                last_main_dt = quotes.index[-1]
+                last_main_dt_end = last_main_dt + utils.interval_to_timedelta(interval)
+                dividends = dividends[dividends.index < last_main_dt_end]
+
                 df = utils.safe_merge_dfs(df, dividends, interval)
                 f_na = df["Dividends"].isna()
                 df.loc[f_na,"Dividends"] = 0
@@ -320,6 +326,12 @@ class TickerBase():
                 df["Dividends"] = 0.0
             #
             if splits.shape[0] > 0:
+                # Discard from splits any rows that fall outside of quotes intervals
+                splits = splits[splits.index >= quotes.index[0]]
+                last_main_dt = quotes.index[-1]
+                last_main_dt_end = last_main_dt + utils.interval_to_timedelta(interval)
+                splits = splits[splits.index < last_main_dt_end]
+
                 df = utils.safe_merge_dfs(df, splits, interval)
                 f_na = df["Stock Splits"].isna()
                 df.loc[f_na,"Stock Splits"] = 0

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -344,10 +344,10 @@ class TickerBase():
                 if interval == "1wk" and splits.shape[0] > 0:
                     splits.index = [dt-_datetime.timedelta(days=dt.weekday()) for dt in splits.index]
                 df = df.join(splits)
-                f_na = df["Splits"].isna()
+                f_na = df["Stock Splits"].isna()
                 if sum(~f_na) < splits.shape[0]:
                     # Splits data was lost. Manually fix index and try again
-                    df = df.drop("Splits",axis=1)
+                    df = df.drop("Stock Splits",axis=1)
                     new_index = []
                     for i in range(splits.shape[0]):
                         dt_d = splits.index[i]
@@ -364,10 +364,10 @@ class TickerBase():
                         new_index.append(dt_d)
                     splits.index = new_index
                     df = df.join(splits)
-                f_na = df["Splits"].isna()
-                df.loc[f_na,"Splits"] = 0
+                f_na = df["Stock Splits"].isna()
+                df.loc[f_na,"Stock Splits"] = 0
             else:
-                df["Splits"] = 0.0
+                df["Stock Splits"] = 0.0
 
         if params["interval"][-1] == "m":
             df.index.name = "Datetime"

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -312,14 +312,14 @@ class TickerBase():
         if actions:
             df = df.sort_index()
             if dividends.shape[0] > 0:
-                df = utils.safe_merge_multiDay_dfs(df, dividends, interval)
+                df = utils.safe_merge_dfs(df, dividends, interval)
                 f_na = df["Dividends"].isna()
                 df.loc[f_na,"Dividends"] = 0
             else:
                 df["Dividends"] = 0.0
             #
             if splits.shape[0] > 0:
-                df = utils.safe_merge_multiDay_dfs(df, splits, interval)
+                df = utils.safe_merge_dfs(df, splits, interval)
                 f_na = df["Stock Splits"].isna()
                 df.loc[f_na,"Stock Splits"] = 0
             else:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -385,9 +385,6 @@ class TickerBase():
 
         self._history = df.copy()
 
-        if not actions:
-            df.drop(columns=["Dividends", "Stock Splits"], inplace=True)
-
         return df
 
     # ------------------------

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -312,58 +312,14 @@ class TickerBase():
         if actions:
             df = df.sort_index()
             if dividends.shape[0] > 0:
-                if interval == "1wk" and dividends.shape[0] > 0:
-                    dividends.index = [dt-_datetime.timedelta(days=dt.weekday()) for dt in dividends.index]
-                df = df.join(dividends)
-                f_na = df["Dividends"].isna()
-                if sum(~f_na) < dividends.shape[0]:
-                    # Dividend data was lost. Manually fix index and try again
-                    df = df.drop("Dividends",axis=1)
-                    new_index = []
-                    for i in range(dividends.shape[0]):
-                        dt_d = dividends.index[i]
-                        if dt_d in df.index:
-                            new_index.append(dt_d) ; continue
-                        # Found a bad index date
-                        fixed = False
-                        for j in range(df.shape[0]):
-                            dt_j = df.index[j]
-                            if dt_d >= dt_j:
-                                dt_d = dt_j ; fixed = True ; break
-                        if not fixed:
-                            raise Exception("Dividends table contains data {} that failed to map to row in prices table".format(dt_d))
-                        new_index.append(dt_d)
-                    dividends.index = new_index
-                    df = df.join(dividends)
+                df = utils.safe_merge_multiDay_dfs(df, dividends, interval)
                 f_na = df["Dividends"].isna()
                 df.loc[f_na,"Dividends"] = 0
             else:
                 df["Dividends"] = 0.0
             #
             if splits.shape[0] > 0:
-                if interval == "1wk" and splits.shape[0] > 0:
-                    splits.index = [dt-_datetime.timedelta(days=dt.weekday()) for dt in splits.index]
-                df = df.join(splits)
-                f_na = df["Stock Splits"].isna()
-                if sum(~f_na) < splits.shape[0]:
-                    # Splits data was lost. Manually fix index and try again
-                    df = df.drop("Stock Splits",axis=1)
-                    new_index = []
-                    for i in range(splits.shape[0]):
-                        dt_d = splits.index[i]
-                        if dt_d in df.index:
-                            new_index.append(dt_d) ; continue
-                        # Found a bad index date
-                        fixed = False
-                        for j in range(df.shape[0]):
-                            dt_j = df.index[j]
-                            if dt_d >= dt_j:
-                                dt_d = dt_j ; fixed = True ; break
-                        if not fixed:
-                            raise Exception("Splits table contains data {} that failed to map to row in prices table".format(dt_d))
-                        new_index.append(dt_d)
-                    splits.index = new_index
-                    df = df.join(splits)
+                df = utils.safe_merge_multiDay_dfs(df, splits, interval)
                 f_na = df["Stock Splits"].isna()
                 df.loc[f_na,"Stock Splits"] = 0
             else:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -303,7 +303,8 @@ class TickerBase():
         quotes.index = quotes.index.tz_localize("UTC").tz_convert(tz_exchange)
         dividends.index = dividends.index.tz_localize("UTC").tz_convert(tz_exchange)
         splits.index = splits.index.tz_localize("UTC").tz_convert(tz_exchange)
-        if params["interval"] in ["1w","1wk"]:
+        if params["interval"] in ["1d","1w","1wk"]:
+            # Converting datetime->date should improve merge performance
             quotes.index = _pd.to_datetime(quotes.index.date)
             dividends.index = _pd.to_datetime(dividends.index.date)
             splits.index = _pd.to_datetime(splits.index.date)

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -254,19 +254,23 @@ def safe_merge_dfs(df_main, df_sub, interval):
         raise Exception("Expected 1 data col")
     data_col = data_cols[0]
 
-    # Discard out-of-range events
+    # Discard last row in 'df_sub' if significantly after last row in df_main.
+    # Size of difference depends on interval.
     df_sub = df_sub[df_sub.index >= df_main.index[0]]
     df_sub_last_dt = df_sub.index[-1]
     df_main_last_dt = df_main.index[-1]
-    if interval == "1mo" and df_sub_last_dt>df_main_last_dt and df_sub_last_dt.month != df_main_last_dt.month:
-        df_sub = df_sub.drop(df_sub.index[-1])
-    elif interval in ["1wk","5d"] and df_sub_last_dt>df_main_last_dt and df_sub_last_dt.week != df_main_last_dt.week:
-        df_sub = df_sub.drop(df_sub.index[-1])
-    elif interval == "1d" and df_sub_last_dt>df_main_last_dt and df_sub_last_dt.day != df_main_last_dt.day:
-        df_sub = df_sub.drop(df_sub.index[-1])
-    if df_sub.shape[0] == 0:
-        # raise Exception("No data to merge after pruning out-of-range")
-        return df_main
+    if df_sub_last_dt > df_main_last_dt:
+        if interval == "1mo" and df_sub_last_dt.month != df_main_last_dt.month:
+            df_sub = df_sub.drop(df_sub.index[-1])
+        elif interval in ["1wk","5d"] and df_sub_last_dt.week != df_main_last_dt.week:
+            df_sub = df_sub.drop(df_sub.index[-1])
+        elif interval == "1d" and df_sub_last_dt.date() > df_main_last_dt.date():
+            df_sub = df_sub.drop(df_sub.index[-1])
+        elif (interval.endswith('h') or interval.endswith('m')) and (df_sub_last_dt.date() > df_main_last_dt.date()):
+            df_sub = df_sub.drop(df_sub.index[-1])
+        if df_sub.shape[0] == 0:
+            # raise Exception("No data to merge after pruning out-of-range")
+            return df_main
 
     df = df_main.join(df_sub)
 

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -263,7 +263,6 @@ def safe_merge_dfs(df_main, df_sub, interval):
     elif interval in ["1wk","5d"] and df_sub_last_dt>df_main_last_dt and df_sub_last_dt.week != df_main_last_dt.week:
         df_sub = df_sub.drop(df_sub.index[-1])
     elif interval == "1d" and df_sub_last_dt>df_main_last_dt and df_sub_last_dt.day != df_main_last_dt.day:
-        print("here")
         df_sub = df_sub.drop(df_sub.index[-1])
     if df_sub.shape[0] == 0:
         # raise Exception("No data to merge after pruning out-of-range")

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -281,7 +281,7 @@ def safe_merge_dfs(df_main, df_sub, interval):
     # Lost data during join(). Manually check each df_sub.index date against df_main.index to
     # find matching interval
     df_sub = df_sub_backup.copy()
-    for i in _np.where(f_na)[0]:
+    for i in range(df_sub.shape[0]):
         dt_sub_i = df_sub.index[i]
         if dt_sub_i in df_main.index:
             new_index[i] = dt_sub_i ; continue

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -281,6 +281,7 @@ def safe_merge_dfs(df_main, df_sub, interval):
     # Lost data during join(). Manually check each df_sub.index date against df_main.index to
     # find matching interval
     df_sub = df_sub_backup.copy()
+    new_index = [-1]*df_sub.shape[0]
     for i in range(df_sub.shape[0]):
         dt_sub_i = df_sub.index[i]
         if dt_sub_i in df_main.index:

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -27,7 +27,6 @@ import pandas as _pd
 import numpy as _np
 import sys as _sys
 import datetime as _datetime
-import dateutil as _dateutil
 
 try:
     import ujson as _json
@@ -238,40 +237,6 @@ def parse_actions(data, tz=None):
             splits = splits[["Stock Splits"]]
 
     return dividends, splits
-
-
-def interval_to_timedelta(interval):
-    if interval == "1mo":
-        td = _dateutil.relativedelta(months=1)
-    elif interval == "3mo":
-        td = _dateutil.relativedelta(months=3)
-    elif interval == "1wk":
-        td = _datetime.timedelta(days=7)
-    elif interval == "5d":
-        td = _datetime.timedelta(days=5)
-    elif interval == "1d":
-        td = _datetime.timedelta(days=1)
-    elif interval == "1h":
-        td = _datetime.timedelta(minutes=60)
-    elif interval == "90m":
-        td = _datetime.timedelta(minutes=90)
-    elif interval == "90m":
-        td = _datetime.timedelta(minutes=90)
-    elif interval == "60m":
-        td = _datetime.timedelta(minutes=60)
-    elif interval == "30m":
-        td = _datetime.timedelta(minutes=30)
-    elif interval == "15m":
-        td = _datetime.timedelta(minutes=15)
-    elif interval == "5m":
-        td = _datetime.timedelta(minutes=5)
-    elif interval == "2m":
-        td = _datetime.timedelta(minutes=2)
-    elif interval == "1m":
-        td = _datetime.timedelta(minutes=1)
-    else:
-        raise Exception("Cannot map interval '{}' to timedelta".format(interval))
-    return td
 
 
 def safe_merge_dfs(df_main, df_sub, interval):

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -27,6 +27,7 @@ import pandas as _pd
 import numpy as _np
 import sys as _sys
 import datetime as _datetime
+import dateutil as _dateutil
 
 try:
     import ujson as _json
@@ -237,6 +238,40 @@ def parse_actions(data, tz=None):
             splits = splits[["Stock Splits"]]
 
     return dividends, splits
+
+
+def interval_to_timedelta(interval):
+    if interval == "1mo":
+        td = _dateutil.relativedelta(months=1)
+    elif interval == "3mo":
+        td = _dateutil.relativedelta(months=3)
+    elif interval == "1wk":
+        td = _datetime.timedelta(days=7)
+    elif interval == "5d":
+        td = _datetime.timedelta(days=5)
+    elif interval == "1d":
+        td = _datetime.timedelta(days=1)
+    elif interval == "1h":
+        td = _datetime.timedelta(minutes=60)
+    elif interval == "90m":
+        td = _datetime.timedelta(minutes=90)
+    elif interval == "90m":
+        td = _datetime.timedelta(minutes=90)
+    elif interval == "60m":
+        td = _datetime.timedelta(minutes=60)
+    elif interval == "30m":
+        td = _datetime.timedelta(minutes=30)
+    elif interval == "15m":
+        td = _datetime.timedelta(minutes=15)
+    elif interval == "5m":
+        td = _datetime.timedelta(minutes=5)
+    elif interval == "2m":
+        td = _datetime.timedelta(minutes=2)
+    elif interval == "1m":
+        td = _datetime.timedelta(minutes=1)
+    else:
+        raise Exception("Cannot map interval '{}' to timedelta".format(interval))
+    return td
 
 
 def safe_merge_dfs(df_main, df_sub, interval):

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -233,7 +233,7 @@ def parse_actions(data, tz=None):
                 splits.index = splits.index.tz_localize(tz)
             splits["Stock Splits"] = splits["numerator"] / \
                 splits["denominator"]
-            splits = splits["Stock Splits"]
+            splits = splits[["Stock Splits"]]
 
     return dividends, splits
 

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -21,12 +21,12 @@
 
 from __future__ import print_function
 
+import datetime as _datetime
 import requests as _requests
 import re as _re
 import pandas as _pd
 import numpy as _np
 import sys as _sys
-import datetime as _datetime
 
 try:
     import ujson as _json


### PR DESCRIPTION
Dividends and splits should be merged with price data not appended to bottom, produces a cleaner table (less NaNs). For weekly/monthly intervals, backdate events to start of week/month for a clean merge.

Merging verifies that no events were lost in process.