### PR TITLE
Bugfix: Relocate out-of-range check to before 15m->30m conversion

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -242,7 +242,7 @@ class TickerBase():
             # Yahoo bug fix - it often appends latest price even if after end date
             if end and not quotes.empty:
                 endDt = _pd.to_datetime(_datetime.datetime.fromtimestamp(end))
-                if quotes.index[quotes.shape[0]-1] > endDt:
+                if quotes.index[quotes.shape[0]-1] >= endDt:
                     quotes = quotes.iloc[0:quotes.shape[0]-1]
         except Exception:
             shared._DFS[self.ticker] = utils.empty_df()

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -241,7 +241,7 @@ class TickerBase():
             quotes = utils.parse_quotes(data["chart"]["result"][0], tz)
             # Yahoo bug fix - it often appends latest price even if after end date
             if end and not quotes.empty:
-                endDt = _pd.to_datetime(_datetime.datetime.fromtimestamp(end))
+                endDt = _pd.to_datetime(_datetime.datetime.utcfromtimestamp(end))
                 if quotes.index[quotes.shape[0]-1] >= endDt:
                     quotes = quotes.iloc[0:quotes.shape[0]-1]
         except Exception:


### PR DESCRIPTION
I was playing with 15m data which is created internally from 30m data - the price-after-end-date bug (https://github.com/ranaroussi/yfinance/pull/1026) was messing with the 15m->30 conversion. So just moving the bug-fix up in code.

I also snuck in a timezone fix: `fromtimestamp()` -> `utcfromtimestamp()`